### PR TITLE
:bug: fix: 使用 `wexpect` 替代 `pexpect` 在 windows 中工作

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,19 @@
 [project]
 name = "yutto-uiya"
-version = "1.0.4"
+version = "1.1.2"
 description = ""
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "pyaml==25.1.0",
-    "pydantic==2.10.6",
-    #"socksio==1.0.0",
-    "httpx[http2,socks]>=0.28.1",
+    "pydantic>=2.10.6",
     "tomli_w==1.2.0",
-    "yutto==2.0.2",
     "streamlit==1.43.2",
-    "pexpect==4.9.0",
+
+    # special
+    "yutto==2.0.3",
+    "httpx[http2,socks]>=0.28.1",
+    "pexpect==4.9.0;sys_platform!='win32'",
+    "wexpect-uv;sys_platform=='win32'",
 ]
 authors = [{ name = "MrXnneHang", email = "XnneHang@gmail.com" }]
 keywords = []
@@ -43,6 +44,8 @@ dev = [
   "pytest-rerunfailures>=15.0",
 ]
 
+[tool.uv.sources]
+wexpect-uv = { git = "https://github.com/XnneHangLab/wexpect-uv.git" , rev = "dev" }
 
 [tool.pyright]
 include = ["src/uiya"]

--- a/src/uiya/__version__.py
+++ b/src/uiya/__version__.py
@@ -1,4 +1,4 @@
 # 发版需要同时改这里和 pyproject.toml
 from __future__ import annotations
 
-VERSION = "1.0.4"
+VERSION = "1.1.2"

--- a/src/uiya/_typing.py
+++ b/src/uiya/_typing.py
@@ -67,4 +67,4 @@ bangumi_status: CommandStatus = {
     "audio_quality": "320kbps",
 }
 
-SupportOS = Literal["windows","linux","macos"]
+SupportOS = Literal["windows", "linux", "macos"]

--- a/src/uiya/_typing.py
+++ b/src/uiya/_typing.py
@@ -66,3 +66,5 @@ bangumi_status: CommandStatus = {
     "video_quality": "360p 流畅",
     "audio_quality": "320kbps",
 }
+
+SupportOS = Literal["windows","linux","macos"]

--- a/src/uiya/utils/TextHelper.py
+++ b/src/uiya/utils/TextHelper.py
@@ -1,36 +1,54 @@
 from __future__ import annotations
 
+import platform
 from uiya._dictionary import emoji
 
 
 def clean_ouput(output: str):
-    # ignore emoji
-    for ignore_value in emoji:
-        output = output.replace(ignore_value, "")
+    if platform.system() == "Windows":
+        output = output.replace("\r\n","")
+        output = output.replace("\r","")
+        output = output.replace("\n","")
+        output = output.replace("INFO","")
+        output = output.replace("WARN","")
+        output = output.replace("ERROR","")
+        
+        # 忽略空行
+        if output.replace(" ","") == "":
+            output = ""        
+        else:
+            output = output + "\n"
+        # print([output])
 
-    # ignore space
-    output = output.replace(" ", "")
+        
+    
+    else:
+        # ignore emoji
+        for ignore_value in emoji:
+            output = output.replace(ignore_value, "")
+        # ignore space
+        output = output.replace(" ", "")
 
-    # ignore color
-    # output = output.replace("\x1b[33m", "")  # WARNING
-    # output = output.replace("\x1b[31;1m", "")  # ERROR
-    output = output.replace("\x1b[94m", "[")
-    output = output.replace("\x1b[93m", "[")
-    output = output.replace("\x1b[91m", "[")
-    output = output.replace("\x1b[92m", "[")
-    output = output.replace("\x1b[0m", "] ")
-    output = output.replace("\x1b[30;46m", "[")
-    output = output.replace("\x1b[32;1m", "")
-    output = output.replace("\x1b[38;2;64;64;64m", "")
-    output = output.replace("\x1b[32m", "")
-    output = output.replace("\x1b[33m", "")
-    output = output.replace("\x1b[31;1m", "")
-    output = output.replace("\x1b[34m*", ">")
-    output = output.replace("\x1b[35m*", ">")
-    output = output.replace("\x1b[0m", "")
-    output = output.replace("\x1b[36m", "")
+        # ignore color
+        # output = output.replace("\x1b[33m", "")  # WARNING
+        # output = output.replace("\x1b[31;1m", "")  # ERROR
+        output = output.replace("\x1b[94m", "[")
+        output = output.replace("\x1b[93m", "[")
+        output = output.replace("\x1b[91m", "[")
+        output = output.replace("\x1b[92m", "[")
+        output = output.replace("\x1b[0m", "] ")
+        output = output.replace("\x1b[30;46m", "[")
+        output = output.replace("\x1b[32;1m", "")
+        output = output.replace("\x1b[38;2;64;64;64m", "")
+        output = output.replace("\x1b[32m", "")
+        output = output.replace("\x1b[33m", "")
+        output = output.replace("\x1b[31;1m", "")
+        output = output.replace("\x1b[34m*", ">")
+        output = output.replace("\x1b[35m*", ">")
+        output = output.replace("\x1b[0m", "")
+        output = output.replace("\x1b[36m", "")
 
-    # Add line break for process line
-    if "━━━" in output:
-        output = output + "\n"
+        # Add line break for process line
+        if "━━━" in output:
+            output = output + "\n"
     return output

--- a/src/uiya/utils/TextHelper.py
+++ b/src/uiya/utils/TextHelper.py
@@ -1,27 +1,26 @@
 from __future__ import annotations
 
 import platform
+
 from uiya._dictionary import emoji
 
 
 def clean_ouput(output: str):
     if platform.system() == "Windows":
-        output = output.replace("\r\n","")
-        output = output.replace("\r","")
-        output = output.replace("\n","")
-        output = output.replace("INFO","")
-        output = output.replace("WARN","")
-        output = output.replace("ERROR","")
-        
+        output = output.replace("\r\n", "")
+        output = output.replace("\r", "")
+        output = output.replace("\n", "")
+        output = output.replace("INFO", "")
+        output = output.replace("WARN", "")
+        output = output.replace("ERROR", "")
+
         # 忽略空行
-        if output.replace(" ","") == "":
-            output = ""        
+        if output.replace(" ", "") == "":
+            output = ""
         else:
             output = output + "\n"
         # print([output])
 
-        
-    
     else:
         # ignore emoji
         for ignore_value in emoji:

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -143,7 +143,7 @@ def run_command(command: list[str], key_name: str) -> int | None:
         # print([output_text])
 
         # 获取退出状态
-        child.close() # type:ignore
+        child.close()  # type:ignore
 
     except Exception as e:
         error_msg: str = f"\n发生错误: {e}\n"

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -1,26 +1,30 @@
 from __future__ import annotations
 
+import platform
 import sys
 import time
-import streamlit as st
-import platform
-from uiya.utils.TextHelper import clean_ouput
-from uiya._typing import SupportOS
+from typing import TYPE_CHECKING
 
+import streamlit as st
+
+from uiya.utils.TextHelper import clean_ouput
+
+if TYPE_CHECKING:
+    from uiya._typing import SupportOS
 # 防止被小写 windows 坑到
 if platform.system() == "Windows":
-    OS:SupportOS = "windows"
+    os: SupportOS = "windows"
 elif platform.system() == "Linux":
-    OS:SupportOS = "linux"
+    os: SupportOS = "linux"
 elif platform.system() == "Darwin":
-    OS:SupportOS = "macos"
+    os: SupportOS = "macos"
 else:
     raise ValueError("Unsupported OS")
 
-if OS == "windows":
-    import wexpect as pexpect
+if os == "windows":
+    import wexpect as pexpect  # type:ignore [import-error]
 else:
-    import pexpect
+    import pexpect  # type:ignore [import-error]
 
 # TODO child 的类型不明确，可能需要找时间修复
 
@@ -53,8 +57,10 @@ def run_command(command: list[str], key_name: str) -> int | None:
 
     child = None
     try:
-        child = pexpect.spawn(
-            command[0], args=command[1:], encoding="utf-8",
+        child = pexpect.spawn(  # type: ignore[assignment]
+            command[0],
+            args=command[1:],
+            encoding="utf-8",
         )
         # 读取并处理输出
         buffer: list[str] = []
@@ -63,31 +69,37 @@ def run_command(command: list[str], key_name: str) -> int | None:
         while True:
             try:
                 # 尝试读取字符
-                index: int = child.expect([".", pexpect.EOF, pexpect.TIMEOUT], timeout=0.1)
+                index: int = child.expect([".", pexpect.EOF, pexpect.TIMEOUT], timeout=0.1)  # type: ignore[assignment]
 
                 if index == 0:  # 读取到一个字符
                     char: str = str(child.after)  # type: ignore[assignment]
                     buffer.append(char)
 
                     # 如果是unix-like,直接输出到终端，如果是windows,则需要先处理一下。
-                    if OS != "windows":
+                    if os != "windows":
                         sys.stdout.write(char)
                     sys.stdout.flush()
 
                     # 定期更新界面
                     current_time: float = time.time()
-                    if OS != "windows":
+                    if os != "windows":
                         update_condition: bool = (
                             char == "\n" or "/s\x1b[0m" in "".join(buffer) or "/⚡\x1b[0m" in "".join(buffer)
                         )
                     else:
-                        update_condition: bool = (char == "\n")  or "加载中……" in "".join(buffer) or "INFO " in "".join(buffer) or "WARN" in "".join(buffer) or "ERROR" in "".join(buffer)
+                        update_condition: bool = (
+                            (char == "\n")
+                            or "加载中……" in "".join(buffer)
+                            or "INFO " in "".join(buffer)
+                            or "WARN" in "".join(buffer)
+                            or "ERROR" in "".join(buffer)
+                        )
 
                     if update_condition:
                         output_text += "".join(buffer)
                         output = clean_ouput("".join(buffer))
-                        if OS == "windows":
-                            if output: # if != ""
+                        if os == "windows":
+                            if output:  # if != ""
                                 print(output)
                         st.session_state[output_key] += output
                         buffer = []

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -143,7 +143,7 @@ def run_command(command: list[str], key_name: str) -> int | None:
         # print([output_text])
 
         # 获取退出状态
-        child.close()
+        child.close() # type:ignore
 
     except Exception as e:
         error_msg: str = f"\n发生错误: {e}\n"

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -2,11 +2,25 @@ from __future__ import annotations
 
 import sys
 import time
-
-import pexpect
 import streamlit as st
-
+import platform
 from uiya.utils.TextHelper import clean_ouput
+from uiya._typing import SupportOS
+
+# 防止被小写 windows 坑到
+if platform.system() == "Windows":
+    OS:SupportOS = "windows"
+elif platform.system() == "Linux":
+    OS:SupportOS = "linux"
+elif platform.system() == "Darwin":
+    OS:SupportOS = "macos"
+else:
+    raise ValueError("Unsupported OS")
+
+if OS == "windows":
+    import wexpect as pexpect
+else:
+    import pexpect
 
 # TODO child 的类型不明确，可能需要找时间修复
 
@@ -37,16 +51,15 @@ def run_command(command: list[str], key_name: str) -> int | None:
     # 显示初始空输出
     output_placeholder.code(st.session_state[output_key], language="bash")
 
-    child: pexpect.spawn | None = None  # type: ignore[assignment]
-
+    child = None
     try:
-        # 启动进程
-        child = pexpect.spawn(command[0], args=command[1:], encoding="utf-8")  # type: ignore[assignment]
-
+        child = pexpect.spawn(
+            command[0], args=command[1:], encoding="utf-8",
+        )
         # 读取并处理输出
         buffer: list[str] = []
         last_update_time: float = time.time()
-
+        output_text = ""
         while True:
             try:
                 # 尝试读取字符
@@ -56,19 +69,26 @@ def run_command(command: list[str], key_name: str) -> int | None:
                     char: str = str(child.after)  # type: ignore[assignment]
                     buffer.append(char)
 
-                    # 输出到终端
-                    sys.stdout.write(char)
+                    # 如果是unix-like,直接输出到终端，如果是windows,则需要先处理一下。
+                    if OS != "windows":
+                        sys.stdout.write(char)
                     sys.stdout.flush()
 
                     # 定期更新界面
                     current_time: float = time.time()
-                    update_condition: bool = (
-                        char == "\n" or "/s\x1b[0m" in "".join(buffer) or "/⚡\x1b[0m" in "".join(buffer)
-                    )
+                    if OS != "windows":
+                        update_condition: bool = (
+                            char == "\n" or "/s\x1b[0m" in "".join(buffer) or "/⚡\x1b[0m" in "".join(buffer)
+                        )
+                    else:
+                        update_condition: bool = (char == "\n")  or "加载中……" in "".join(buffer) or "INFO " in "".join(buffer) or "WARN" in "".join(buffer) or "ERROR" in "".join(buffer)
 
                     if update_condition:
+                        output_text += "".join(buffer)
                         output = clean_ouput("".join(buffer))
-                        # print(["".join(buffer)])
+                        if OS == "windows":
+                            if output: # if != ""
+                                print(output)
                         st.session_state[output_key] += output
                         buffer = []
                         last_update_time = current_time
@@ -82,6 +102,8 @@ def run_command(command: list[str], key_name: str) -> int | None:
                         sys.stdout.flush()
 
                     if buffer:
+                        # 匹配解析时输出的 `投稿视频 ...``
+                        output_text += "".join(buffer)
                         output = clean_ouput("".join(buffer))
                         st.session_state[output_key] += output
                         output_placeholder.code(st.session_state[output_key], language="bash")
@@ -90,6 +112,7 @@ def run_command(command: list[str], key_name: str) -> int | None:
                 elif index == 2:  # 超时
                     current_time: float = time.time()
                     if buffer and (current_time - last_update_time) > 0.5:
+                        output_text += "".join(buffer)
                         output = clean_ouput("".join(buffer))
                         st.session_state[output_key] += output
                         buffer = []
@@ -100,9 +123,12 @@ def run_command(command: list[str], key_name: str) -> int | None:
             except Exception as e:
                 error_msg: str = f"\n读取过程中发生错误: {e}\n"
                 st.session_state[output_key] += error_msg
-                # print(error_msg, file=sys.stderr)
+                print(error_msg, file=sys.stderr)
                 output_placeholder.code(st.session_state[output_key], language="bash")
                 break
+
+        # 未经处理的原始字符集
+        # print([output_text])
 
         # 获取退出状态
         child.close()
@@ -110,7 +136,7 @@ def run_command(command: list[str], key_name: str) -> int | None:
     except Exception as e:
         error_msg: str = f"\n发生错误: {e}\n"
         st.session_state[output_key] += error_msg
-        # print(error_msg, file=sys.stderr)
+        print(error_msg, file=sys.stderr)
         output_placeholder.code(st.session_state[output_key], language="bash")
 
     finally:

--- a/src/uiya/yutto_uiya.py
+++ b/src/uiya/yutto_uiya.py
@@ -101,7 +101,6 @@ def single_video_tab():
             status.update({"audio_quality": audio_quality})
             command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
             command = command_generator.gen_args()
-
             # 使用特定的key名称
             run_command(command, key_name="single_video_output")
 


### PR DESCRIPTION
- https://github.com/XnneHangLab/yutto-uiya/pull/3
pexpect 只在 unix-like 的终端里工作。

这里在提供 windows 下的工作方式。
依然存在的较难修复的问题.
- wexpect 捕获不完整, 终端的输出并不是直接的输出，而是我处理后的输出
- 进度条无法被捕获，终端和 UI 中进度条都不可见。

待办:

- [x] 发布 `wexpect` 到 pypi 
- [x] 修改 wexpect 源码使它可以正常捕获输出内容以及进度条。 


修复了 windows 下无法直接使用 pexpect.spawn 的问题。