### PR TITLE
:sparkles: feature: 在 Windows 中捕获进度条.

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,6 +10,8 @@ fmt:
 lint:
   uv run pyright src/uiya
   uv run ruff check .
+
+fmt-docs:
   prettier --ignore-path .prettierignore --write '**/*.md'
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "yutto==2.0.3",
     "httpx[http2,socks]>=0.28.1",
     "pexpect==4.9.0;sys_platform!='win32'",
-    "wexpect-uv==0.0.1;sys_platform=='win32'",
+    "wexpect-uv==0.0.2;sys_platform=='win32'",
 ]
 authors = [{ name = "MrXnneHang", email = "XnneHang@gmail.com" }]
 keywords = []

--- a/src/uiya/utils/TextHelper.py
+++ b/src/uiya/utils/TextHelper.py
@@ -7,6 +7,8 @@ from uiya._dictionary import emoji
 
 def clean_ouput(output: str):
     if platform.system() == "Windows":
+        for ignore_value in emoji:
+            output = output.replace(ignore_value, "")
         output = output.replace("\r\n", "")
         output = output.replace("\r", "")
         output = output.replace("\n", "")

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -89,7 +89,7 @@ def run_command(command: list[str], key_name: str) -> int | None:
                     else:
                         update_condition: bool = (
                             (char == "\n")
-                            or "……" in "".join(buffer) # 开始下载..... & 加载中.....
+                            or "……" in "".join(buffer)  # 开始下载..... & 加载中.....
                             or "INFO " in "".join(buffer)
                             or "WARN" in "".join(buffer)
                             or "ERROR" in "".join(buffer)

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -93,7 +93,7 @@ def run_command(command: list[str], key_name: str) -> int | None:
                             or "INFO " in "".join(buffer)
                             or "WARN" in "".join(buffer)
                             or "ERROR" in "".join(buffer)
-                            or "⚡" in "".join(buffer)
+                            or "⚡  " in "".join(buffer)
                         )
 
                     if update_condition:
@@ -141,7 +141,7 @@ def run_command(command: list[str], key_name: str) -> int | None:
                 break
 
         # 未经处理的原始字符集
-        # print([output_text])
+        print([output_text])
 
         # 获取退出状态
         child.close()  # type:ignore

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -89,10 +89,11 @@ def run_command(command: list[str], key_name: str) -> int | None:
                     else:
                         update_condition: bool = (
                             (char == "\n")
-                            or "加载中……" in "".join(buffer)
+                            or "……" in "".join(buffer) # 开始下载..... & 加载中.....
                             or "INFO " in "".join(buffer)
                             or "WARN" in "".join(buffer)
                             or "ERROR" in "".join(buffer)
+                            or "⚡" in "".join(buffer)
                         )
 
                     if update_condition:


### PR DESCRIPTION
- [x] wexpect-uv -> 0.0.2
- [x] 对捕获到的进度条 reformat

windows 样例:

```shell
发现配置文件 config\yutto.toml，加载中……
 未提供 SESSDATA，无法下载高清视频、字幕等资源哦～
   投稿视频  用 bilili 下载 B 站视频   
 开始处理视频 用 bilili 下载 B 站视频  
 共包含以下 2 个视频流：  
 * 0 [AVC ] [ 852x480 ] <480P 清晰 > #3  
   1 [AVC ] [ 640x360 ] <360P 流畅 > #3  
 共包含以下 3 个音频流：
   0 [MP4A] <128kbps >
   1 [MP4A] < 64kbps >
 * 2 [MP4A] <320kbps >
 开始下载……
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 320.00 KiB/ 14.37 MiB 1.34 MiB/s    
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   3.06 MiB/ 14.37 MiB 11.00 MiB/⚡  
━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━   9.12 MiB/ 14.37 MiB 23.89 MiB/⚡  
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  14.37 MiB/ 14.37 MiB 19.73 MiB⚡  
 下载完成！                                                              
 开始合并……
 合并完成！
```

linux 参见:

- https://github.com/XnneHangLab/yutto-uiya/pull/3


之前捕获不到，是因为 yutto-uiya 对于进度条以及表情都是用 print("",end="\r")

在 windows 中，相当于仅仅只把光标定位到行首，而不换行， wexpect 的缺陷就在于，它过于依赖于光标位置，不换行，就不更新。

而这次在 v0.0.2 中我加入对行内容的检查，如果行不变但内容改变，也进行刷新。

- https://github.com/XnneHangLab/wexpect-uv/commit/dd48de0be107614fee042c177289c01f98d92c7e