### PR TITLE
:bug: fix: use `parse_status` show errors to user instead of raise error.

### DIFF
--- a/src/uiya/_dataclass.py
+++ b/src/uiya/_dataclass.py
@@ -102,6 +102,7 @@ class CommandGenerator:
         return True
 
     def gen_args(self):
+        # TODO 直接在这里 raise, 会导致 UI 直接崩溃, 所以要提前检查，这里只是作为最后的检查
         # ================== URL
         # URL not correct
         if self.url == "" or not self.url_check(self.url):

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -10,7 +10,10 @@ import streamlit as st
 from uiya.utils.TextHelper import clean_ouput
 
 if TYPE_CHECKING:
-    from uiya._typing import SupportOS
+    from streamlit.delta_generator import DeltaGenerator
+
+    from uiya._typing import CommandStatus, SupportOS
+
 # 防止被小写 windows 坑到
 if platform.system() == "Windows":
     os: SupportOS = "windows"
@@ -26,10 +29,34 @@ if os == "windows":
 else:
     import pexpect  # type:ignore [import-error]
 
+
+def parse_status(status: CommandStatus, key_name: str, output_placeholder: DeltaGenerator) -> bool:
+    """检查 Command status 并且提前返回错误. 防止用户触发 raise 异常导致 UI 崩溃"""
+    # 初始化或清空输出
+    output_key: str = f"{key_name}_content"
+    if output_key not in st.session_state:
+        st.session_state[output_key] = ""
+    else:
+        st.session_state[output_key] = ""
+    # 用户没有输入 URL
+    # TODO 应该检查合法性
+    if not status["url"]:
+        st.session_state[output_key] = "URL 不能为空"
+        output_placeholder.code(st.session_state[output_key], language="bash")
+        return False
+    elif not (
+        status["require_video"] or status["require_audio"] or status["require_danmaku"] or status["require_cover"]
+    ):
+        st.session_state[output_key] = "至少需要选择一个资源项"
+        output_placeholder.code(st.session_state[output_key], language="bash")
+        return False
+    else:
+        output_placeholder.code(st.session_state[output_key], language="bash")
+        return True
+
+
 # TODO child 的类型不明确，可能需要找时间修复
-
-
-def run_command(command: list[str], key_name: str) -> int | None:
+def run_command(command: list[str], key_name: str, output_placeholder: DeltaGenerator) -> int | None:
     """
     使用 pexpect 运行命令并实时更新 Streamlit 界面，同时保留终端原始输出
 
@@ -48,9 +75,6 @@ def run_command(command: list[str], key_name: str) -> int | None:
         st.session_state[output_key] = ""
     else:
         st.session_state[output_key] = ""
-
-    # 创建占位符用于更新
-    output_placeholder = st.empty()
 
     # 显示初始空输出
     output_placeholder.code(st.session_state[output_key], language="bash")
@@ -141,7 +165,7 @@ def run_command(command: list[str], key_name: str) -> int | None:
                 break
 
         # 未经处理的原始字符集
-        print([output_text])
+        # print([output_text])
 
         # 获取退出状态
         child.close()  # type:ignore

--- a/src/uiya/yutto_uiya.py
+++ b/src/uiya/yutto_uiya.py
@@ -6,7 +6,7 @@ from uiya._dataclass import CommandGenerator
 from uiya._typing import AudioQuality, VideoQuality, bangumi_status, video_status
 from uiya.styles.global_style import style
 from uiya.utils.config import UiyaSetting, get_setting_title, load_settings_file, write_settings_file
-from uiya.utils.runner import run_command
+from uiya.utils.runner import parse_status, run_command
 
 if "save" in st.session_state:
     st.toast("参数已成功保存", icon=":material/verified:")
@@ -99,10 +99,15 @@ def single_video_tab():
             status.update({"debug_mode": debug_mode})
             status.update({"video_quality": video_quality})
             status.update({"audio_quality": audio_quality})
-            command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
-            command = command_generator.gen_args()
-            # 使用特定的key名称
-            run_command(command, key_name="single_video_output")
+
+            output_placeholder = st.empty()
+            if parse_status(status, key_name="single_video_parse", output_placeholder=output_placeholder):  # 解析状态
+                command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
+                command = command_generator.gen_args()
+                # 使用特定的key名称
+                run_command(command, key_name="single_video_output", output_placeholder=output_placeholder)
+            else:
+                st.session_state.is_running = False
 
 
 def video_list_tab() -> None:
@@ -181,11 +186,15 @@ def video_list_tab() -> None:
             status.update({"video_quality": video_quality})
             status.update({"audio_quality": audio_quality})
 
-            command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
-            command = command_generator.gen_args()
+            output_placeholder = st.empty()
+            if parse_status(status, key_name="video_list_parse", output_placeholder=output_placeholder):  # 解析状态
+                command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
+                command = command_generator.gen_args()
 
-            # 使用特定的key名称
-            run_command(command, key_name="video_list_output")
+                # 使用特定的key名称
+                run_command(command, key_name="video_list_output", output_placeholder=output_placeholder)
+            else:
+                st.session_state.is_running = False
 
 
 def favorite_tab() -> None:
@@ -260,11 +269,15 @@ def favorite_tab() -> None:
             status.update({"video_quality": video_quality})
             status.update({"audio_quality": audio_quality})
 
-            command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
-            command = command_generator.gen_args()
+            output_placeholder = st.empty()
+            if parse_status(status, key_name="favor_list_parse", output_placeholder=output_placeholder):  # 解析状态
+                command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
+                command = command_generator.gen_args()
 
-            # 使用特定的key名称
-            run_command(command, key_name="favor_list_output")
+                # 使用特定的key名称
+                run_command(command, key_name="favor_list_output", output_placeholder=output_placeholder)
+            else:
+                st.session_state.is_running = False
 
 
 def collection_tab() -> None:
@@ -339,11 +352,15 @@ def collection_tab() -> None:
             status.update({"video_quality": video_quality})
             status.update({"audio_quality": audio_quality})
 
-            command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
-            command = command_generator.gen_args()
+            output_placeholder = st.empty()
+            if parse_status(status, key_name="collection_parse", output_placeholder=output_placeholder):
+                command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
+                command = command_generator.gen_args()
 
-            # 使用特定的key名称
-            run_command(command, key_name="collection_output")
+                # 使用特定的key名称
+                run_command(command, key_name="collection_output", output_placeholder=output_placeholder)
+            else:
+                st.session_state.is_running = False
 
 
 def bangumi_tab() -> None:
@@ -422,11 +439,16 @@ def bangumi_tab() -> None:
             status.update({"debug_mode": debug_mode})
             status.update({"video_quality": video_quality})
             status.update({"audio_quality": audio_quality})
-            command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
-            command = command_generator.gen_args()
 
-            # 使用特定的key名称
-            run_command(command, key_name="bangumi_output")
+            output_placeholder = st.empty()
+            if parse_status(status, key_name="bangumi_parse", output_placeholder=output_placeholder):  # 解析状态
+                command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
+                command = command_generator.gen_args()
+
+                # 使用特定的key名称
+                run_command(command, key_name="bangumi_output", output_placeholder=output_placeholder)
+            else:
+                st.session_state.is_running = False
 
 
 def setting_tab() -> None:


### PR DESCRIPTION
## 动机
raise error 会打断 streamlit 的 UI 进程，只有刷新页面才能恢复。使用体验不佳。
目前提前检查 status 把 error 提前扔到了 output box 中.

- [x] 防止 raise 打断 UI 进程