### PR TITLE
:bug: fix:  some module  need arg `-b` 

### DIFF
--- a/src/uiya/_dataclass.py
+++ b/src/uiya/_dataclass.py
@@ -145,8 +145,11 @@ class CommandGenerator:
         toml_args = ["--config", str(yutto_setting_path)]
         self.args.extend(toml_args)
         # =================== BATCH DOWNLOAD
+        if self.batch_download:
+            batch_download_args = ["-b"]
+            self.args.extend(batch_download_args)
         if self.support_select and self.selected_p is not None:
-            batch_download_args = ["-b", "-p", self.selected_p]
+            batch_download_args = ["-p", self.selected_p]
             self.args.extend(batch_download_args)
         # =================== DEBUG MODE
         if self.debug_mode:

--- a/src/uiya/_typing.py
+++ b/src/uiya/_typing.py
@@ -25,8 +25,10 @@ class CommandStatus(TypedDict):
 
     target_type: TargetType
     url: str
-    batch_download: bool  # bangumi:True, video: False, video_list: True, collection: True, Favor: True
-    support_select: bool  # bangumi: True, video: False, video_list: True, collection: False, space: False, Favor: False
+    batch_download: (
+        bool  # bangumi:True, video: False, video_list: True, collection: True, Favor: True, bangumi_list: True
+    )
+    support_select: bool  # bangumi: True, video: False, video_list: True, collection: False, space: False, Favor: False, bangumi_list: False
     selected_p: str | None  # Optional
     require_video: bool
     require_audio: bool


### PR DESCRIPTION
# 动机:

```shell
[INFO] 发现配置文件config/yutto.toml，加载中….
[INFO] 未提供SESSDATA，无法下载高清视频、字幕等资源哦～
ERROR] url不正确，也许该url仅支持批量下载，如果是这样，请使用参数-b～
[INFO] 已终止下载，再次运行即可继续下载～
```

不小心把 `-b` 和 `-p` 绑定了，其实并不是每个都支持 `-p` ， 所以导致一些比如收藏夹会缺少 `-b` 参数.