### PR TITLE
:recycle: refactor: remove `is_running`.

### DIFF
--- a/src/uiya/_session_keys.py
+++ b/src/uiya/_session_keys.py
@@ -14,12 +14,10 @@ runner_keys: RunnerKeys = {
     "video_name": "video_name",
     "parse_command_status": "parse_command_status",
     "download_content": "download_content",
-    "is_running": "is_running",
     "runtime_error": "runtime_error",
 }
 
 yutto_uiya_keys: YuttoUiyaKeys = {
-    "is_running": "is_running",
     "save": "save",
     "full_status": "full_status",
 }

--- a/src/uiya/_typing.py
+++ b/src/uiya/_typing.py
@@ -107,15 +107,11 @@ class RunnerKeys(TypedDict):
     video_name: str  # 整个视频的名称
     download_content: str  # 下载 output, 和终端保持一致
     parse_command_status: str  # 解析 CommandStatus 格式
-    is_running: str  # 是否正在运行
     runtime_error: str  # 运行时错误
 
 
 class YuttoUiyaKeys(TypedDict):
     """Session keys use in yutto_uiya.py"""
 
-    is_running: str  # 是否正在运行
-
     save: str  # 是否保存(信息提示)
-
     full_status: str  # 用于保存完整的状态信息, 防止二次被篡改

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -42,8 +42,6 @@ if runner_keys["download_content"] not in st.session_state:
     st.session_state[runner_keys["download_content"]] = ""
 if runner_keys["parse_command_status"] not in st.session_state:
     st.session_state[runner_keys["parse_command_status"]] = ""
-if runner_keys["is_running"] not in st.session_state:
-    st.session_state[runner_keys["is_running"]] = False
 if runner_keys["runtime_error"] not in st.session_state:
     st.session_state[runner_keys["runtime_error"]] = ""
 if runner_keys["video_name"] not in st.session_state:
@@ -57,7 +55,6 @@ def initial_keys() -> None:
     st.session_state[runner_keys["parse_content"]] = []
     st.session_state[runner_keys["download_content"]] = ""
     st.session_state[runner_keys["parse_command_status"]] = ""
-    st.session_state[runner_keys["is_running"]] = False
     st.session_state[runner_keys["runtime_error"]] = ""
     st.session_state[runner_keys["video_name"]] = ""
 
@@ -95,6 +92,7 @@ def run_downloader(command: list[str], output_placeholder: DeltaGenerator) -> in
     Returns:
         命令执行的退出状态码，如果无法获取则返回 None
     """
+    st.toast("开始下载,再次点击会重新运行,运行中慎用!", icon=":material/verified:")
     output_key = runner_keys["download_content"]
     # 显示初始空输出
     st.session_state[output_key] = ""
@@ -194,9 +192,6 @@ def run_downloader(command: list[str], output_placeholder: DeltaGenerator) -> in
         print(error_msg, file=sys.stderr)
         output_placeholder.code(st.session_state[output_key], language="bash")
 
-    finally:
-        st.session_state.is_running = False
-
     return child.exitstatus if child and hasattr(child, "exitstatus") else None  # type: ignore[assignment]
 
 
@@ -215,6 +210,7 @@ def run_parser(command: list[str], debug: bool = False, batch: bool = True) -> Y
     Returns:
         命令执行的退出状态码，如果无法获取则返回 None
     """
+    st.toast("开始解析,再次点击会重新运行,运行中慎用!", icon=":material/verified:")
     key = runner_keys["parse_content"]
     child = None
     parser = YuttoOutputParser()
@@ -289,7 +285,6 @@ def run_parser(command: list[str], debug: bool = False, batch: bool = True) -> Y
         print(error_msg, file=sys.stderr)
     finally:
         if debug:
-            st.session_state.is_running = False
             print([output_text])
             print([parser.result])
             st.session_state[key].append(parser.result["episodes"][show_index])
@@ -299,11 +294,9 @@ def run_parser(command: list[str], debug: bool = False, batch: bool = True) -> Y
         else:
             try:
                 if "url 不正确，也许该 url 仅支持批量下载，如果是这样，请使用参数 -b～" in output_text:
-                    st.session_state[runner_keys["is_running"]] = False
                     output_text += "请尝试使用`全集解析` \r\n"
                     st.session_state[runner_keys["runtime_error"]] = clean_ouput(output_text)
                 else:
-                    st.session_state.is_running = False
                     st.session_state[key].append(parser.result["episodes"][show_index])
                     st.session_state[runner_keys["video_name"]] = parser.result["video_name"]
                     show_index += 1

--- a/src/uiya/yutto_uiya.py
+++ b/src/uiya/yutto_uiya.py
@@ -28,9 +28,6 @@ if yutto_uiya_keys["save"] in st.session_state:
     st.toast("参数已成功保存", icon=":material/verified:")
     del st.session_state[yutto_uiya_keys["save"]]
 
-if yutto_uiya_keys["is_running"] not in st.session_state:
-    st.session_state.is_running = False
-
 if yutto_uiya_keys["save"] in st.session_state:
     st.toast("参数已成功保存", icon=":material/verified:")
     del st.session_state[yutto_uiya_keys["save"]]
@@ -94,7 +91,6 @@ def downloader(
     download_button = st.button(
         "开始下载",
         use_container_width=True,
-        disabled=st.session_state[yutto_uiya_keys["is_running"]],
         type="primary",
     )
     output_placeholder = st.empty()
@@ -117,7 +113,6 @@ def downloader(
             command_generator = command_generator.from_status(status)  # 通过from_status来初始化
             command = command_generator.gen_args()
             run_downloader(command=command, output_placeholder=output_placeholder)
-            st.session_state[yutto_uiya_keys["is_running"]] = True
             # 把资源从 tmp_dir 中捞出来
             tmp_dir = Path(command_generator.tmp_dir)
             if tmp_dir.exists():
@@ -139,8 +134,6 @@ def downloader(
                     if file.is_file():
                         file.unlink()
                 tmp_dir.rmdir()
-        st.session_state[yutto_uiya_keys["is_running"]] = False
-        st.rerun()
 
 
 def bangumi_tab() -> None:
@@ -152,16 +145,16 @@ def bangumi_tab() -> None:
             url = st.text_input("URL", key="bangumi_url", placeholder="请输入番剧链接", label_visibility="collapsed")
         with parse_btn_col:
             parse_btn = st.form_submit_button(
-                "单集解析", use_container_width=True, disabled=st.session_state[yutto_uiya_keys["is_running"]]
+                "单集解析",
+                use_container_width=True,
             )
         with batch_parse_btn_col:
             batch_parse_btn = st.form_submit_button(
-                "全集解析", use_container_width=True, disabled=st.session_state[yutto_uiya_keys["is_running"]]
+                "全集解析",
+                use_container_width=True,
             )
     output_placeholder = st.empty()
-    if batch_parse_btn and not st.session_state[yutto_uiya_keys["is_running"]]:
-        st.session_state[yutto_uiya_keys["is_running"]] = True
-
+    if batch_parse_btn:
         status = deepcopy(st.session_state[yutto_uiya_keys["full_status"]])
         # 用户自定义参数,由 UI 传入
         status["url"] = url
@@ -175,10 +168,7 @@ def bangumi_tab() -> None:
             # run_downloader(command, key_name="bangumi_output", output_placeholder=output_placeholder)
             run_parser(command=command, debug=False)
             st.rerun()
-        else:
-            st.session_state[yutto_uiya_keys["is_running"]] = False
-    if parse_btn and not st.session_state[yutto_uiya_keys["is_running"]]:
-        st.session_state[yutto_uiya_keys["is_running"]] = True
+    if parse_btn:
         status = deepcopy(st.session_state[yutto_uiya_keys["full_status"]])
         status["url"] = url
         status["batch_download"] = False
@@ -188,11 +178,6 @@ def bangumi_tab() -> None:
             command = command_generator.gen_args()
             run_parser(command=command, debug=False, batch=False)
             st.rerun()
-        else:
-            st.session_state[yutto_uiya_keys["is_running"]] = False
-
-    if st.session_state[yutto_uiya_keys["is_running"]]:
-        print("正在运行")
 
     if st.session_state[runner_keys["parse_content"]]:
         # 去掉完全相同的元素


### PR DESCRIPTION
去除无用变量 `st.session_state["is_running"]` , 原本它用于禁止运行时连续运行下载或者解析.

但是 streamlit 本身就可以防止意外异步执行, 当一个进程被激发, 上一个进程就会自动停止. 这个性质很好, 可以让用户在中途变卦的时候能够更换其他解析或者下载目标.

所以现在的使用逻辑时, 即使运行时, 依然可以触发解析或下载, 只不过, 它会放弃上一个任务. 相当于重新执行. 这比用户一旦运行就无法停止要好.