### PR TITLE
:bug: fix: fix parsing issues caused by terminal ANSI color codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ README_douban.md
 
 # images
 images/
+
+docs/guide_douban.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "tomli_w==1.2.0",
     "streamlit==1.43.2",
     # special
-    "uiya-yutto==0.0.1",
+    "uiya-yutto==0.0.2-pre",
     # "uiya-yutto",
     "httpx[http2,socks]>=0.28.1",
     "pexpect==4.9.0;sys_platform!='win32'",
@@ -72,6 +72,7 @@ default= true
 [tool.uv.sources]
 # uiya-yutto = { path = "./packages/yutto/dist/uiya_yutto-0.0.1-py3-none-any.whl"}
 # wexpect-uv = {path="./packages/wexpect-uv/dist/wexpect_uv-0.0.4-py3-none-any.whl"}
+# uiya-yutto = {git = "https://github.com/MrXnneHang/yutto.git" , rev = "win10-parse"}
 
 [tool.pyright]
 include = ["src/uiya"]

--- a/src/uiya/utils/TextHelper.py
+++ b/src/uiya/utils/TextHelper.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import ast
 import platform
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, get_args
 
 from uiya._dictionary import emoji
 
-if TYPE_CHECKING:
-    from uiya._typing import AudioQuality, VideoQuality, YuttoParseResult
+
+from uiya._typing import AudioQuality, VideoQuality, YuttoParseResult
 
 
 def clean_ouput(output: str):
@@ -72,143 +72,24 @@ class YuttoOutputParser:
             "稍后再看",
         ]
 
-    # 只解析单集
-    def parse_line(self, line: str) -> None:
-        print([line])
-        """
-        逐行解析输出
-        """
-
-        # 提取总集数
-        self.result["episodes_count"] = 1
-        if len(self.result["episodes"]) == 0:
-            self.result["episodes"].append(
-                {
-                    "title": "",
-                    "link": "",
-                    "video_quality_list": [],
-                    "audio_quality_list": [],
-                    "has_danmaku": False,
-                    "has_subtitle": False,
-                    "has_chapter_info": False,
-                    "metadata": None,
-                    "cover_link": "",
-                }
-            )
-
-        # 提取视频名称
-        for video_name_type in self.video_name_types:
-            if line.startswith(f" {video_name_type} "):
-                self.current_value = line[len(video_name_type) + 2].replace(" ", "")
-                self.current_type = "video_name"
-                self.result[self.current_type] = self.current_value.strip()
-                self.result["episodes"][0]["title"] = self.current_value.strip()
-                return None
-
-        if line.startswith(" LINK "):  # pexpect or wexpect
-            self.current_value = line[6:].replace(" ", "").replace("\r\n", "")
-            self.current_type = "link"
-            self.result["episodes"][0][self.current_type] = self.current_value
-            # 如果 LINK 以 p=? 结尾,那么提取 ?
-            if "p=" in self.current_value:
-                page_match = re.search(r"p=(\d+)", self.current_value)
-                if page_match:
-                    page = int(page_match.group(1))
-                    self.result["video_name"] += f"(p={page})"
-
-        # 检查是否有弹幕
-        if line.startswith(" 弹幕 "):
-            self.current_value = True
-            self.current_type = "has_danmaku"
-            self.result["episodes"][0][self.current_type] = self.current_value
-
-        # 检查是否有字幕
-        if line.startswith(" 字幕 "):
-            self.current_value = True
-            self.current_type = "has_subtitle"
-            self.result["episodes"][0][self.current_type] = self.current_value
-
-        # 检查是否有章节信息
-        if line.startswith(" 章节 "):
-            self.current_value = True
-            self.current_type = "has_chapter_info"
-            self.result["episodes"][0][self.current_type] = self.current_value
-
-        if line.startswith(" 描述文件 "):  # pexpect or wexpect
-            # 提取从"描述文件"后面的所有内容作为元数据开始
-            meta_part = line[6:].replace("\r\n", "").replace(" ", "")
-            self.current_type = "metadata"
-            self.current_value = meta_part
-
-            try:
-                self.current_value = ast.literal_eval(self.current_value)
-                self.result["episodes"][0]["metadata"] = self.current_value
-                if self.result["episodes"][0]["metadata"]["title"]:
-                    self.result["episodes"][0]["title"] = self.result["episodes"][0]["metadata"]["title"]
-            except Exception as E:
-                print(f"{E}")
-                # 继续收集，可能跨多行
-
-        # 提取封面链接（如果之前没提取到）
-        if line.startswith(" 封面 ") and "http" in line:
-            self.current_value = line[4:].replace(" ", "").replace("\r\n", "")
-            self.current_type = "cover_link"
-            self.result["episodes"][0][self.current_type] = str(self.current_value)
-
-        if line.startswith(" 视频质量 "):
-            self.current_type = "video_quality_list"
-            quality_match = re.search(r"<([^>]*)>", line)
-            if quality_match:
-                quality: VideoQuality = quality_match.group(1).strip()  # type: ignore
-                self.current_value = quality
-                self.result["episodes"][self.current_index][self.current_type].append(self.current_value)
-        # 处理音频流
-        if line.startswith(" 音频质量 "):
-            self.current_type = "audio_quality_list"
-            bitrate_match = re.search(r"<([^>]*)>", line)
-            if bitrate_match:
-                bitrate: AudioQuality = bitrate_match.group(1).strip()  # type:ignore
-                self.current_value = bitrate
-                self.result["episodes"][self.current_index][self.current_type].append(self.current_value)
-
-    # 批量解析
-    def batch_parse_line(self, line: str) -> None:
-        """
-        逐行解析输出，当一集解析完成时返回该集的信息
-        """
-        # 清理行
-        # 提取视频名称
-        # 提取视频名称
-        for video_name_type in self.video_name_types:
-            if line.startswith(f" {video_name_type} "):
-                self.current_value = line[len(video_name_type) + 2].replace(" ", "")
-                self.current_type = "video_name"
-                self.result[self.current_type] = self.current_value.strip()
-                return None
-
-        # 提取总集数
-        if line.startswith(" 全集 "):  # wexpect and pexpect as the same
+    def parse_line(self, line: str, is_batch: bool = False) -> None:
+        # 批量时解析总集数
+        if is_batch and line.startswith(" 全集 "):
             episodes_count_match = re.search(r"全\s+(\d+)\s+话", line)
             if episodes_count_match:
-                self.current_value = episodes_count_match.group(1)
-                self.current_type = "episodes_count"
-                self.result[self.current_type] = int(self.current_value)
-            return None
+                self.result["episodes_count"] = int(episodes_count_match.group(1))
+            return
 
-        # 新的一集开始
-        if line.startswith(" ["):  # [2/4]
+        # 批量模式下判断新的一集
+        if is_batch and line.startswith(" ["):
             pattern = r"\[(\d+)/(\d+)\]\s+(.*)"
             episode_start_match = re.search(pattern, line)
             if episode_start_match:
-                self.current_value = int(episode_start_match.group(1)) - 1
-                self.current_type = "current_episode_index"
-                self.result[self.current_type] = self.current_value
-
-                self.current_value = episode_start_match.group(3).replace("\x1b[0m", "").replace(" ", "")
-                self.current_type = "title"
+                self.result["current_episode_index"] = int(episode_start_match.group(1)) - 1
+                title = episode_start_match.group(3).replace("\x1b[0m", "").replace(" ", "")
                 self.result["episodes"].append(
                     {
-                        self.current_type: self.current_value,
+                        "title": title,
                         "link": "",
                         "video_quality_list": [],
                         "audio_quality_list": [],
@@ -219,69 +100,90 @@ class YuttoOutputParser:
                         "cover_link": "",
                     }
                 )
+            return
 
-        self.current_index = self.result["current_episode_index"]
-        # collect episode info
-        if self.current_index != -1:
-            # 提取链接
-            if line.startswith(" LINK"):  # pexpect or wexpect
-                self.current_value = line[6:].replace(" ", "").replace("\r\n", "")
-                self.current_type = "link"
-                self.result["episodes"][self.current_index][self.current_type] = self.current_value
+        # 非批量时只初始化一次集
+        if not is_batch:
+            self.result["episodes_count"] = 1
+            if len(self.result["episodes"]) == 0:
+                self.result["episodes"].append(
+                    {
+                        "title": "",
+                        "link": "",
+                        "video_quality_list": [],
+                        "audio_quality_list": [],
+                        "has_danmaku": False,
+                        "has_subtitle": False,
+                        "has_chapter_info": False,
+                        "metadata": None,
+                        "cover_link": "",
+                    }
+                )
+            self.result["current_episode_index"] = 0
 
-            # 检查是否有弹幕
-            if line.startswith(" 弹幕 "):
-                self.current_value = True
-                self.current_type = "has_danmaku"
-                self.result["episodes"][self.current_index][self.current_type] = self.current_value
+        # 选择当前集索引
+        self.current_index = self.result.get("current_episode_index", 0)
 
-            # 检查是否有字幕
-            if line.startswith(" 字幕 "):
-                self.current_value = True
-                self.current_type = "has_subtitle"
-                self.result["episodes"][self.current_index][self.current_type] = self.current_value
+        # 提取视频名
+        for video_name_type in self.video_name_types:
+            if line.startswith(f" {video_name_type} "):
+                value = line[len(video_name_type) + 2 :].replace(" ", "")
+                self.result["video_name"] = value.strip()
+                if not is_batch:
+                    self.result["episodes"][self.current_index]["title"] = value.strip()
+                return
 
-            # 检查是否有章节信息
-            if line.startswith(" 章节 "):
-                self.current_value = True
-                self.current_type = "has_chapter_info"
-                self.result["episodes"][self.current_index][self.current_type] = self.current_value
+        # LINK
+        if line.startswith(" LINK"):
+            value = line[6:].replace(" ", "").replace("\r\n", "")
+            self.result["episodes"][self.current_index]["link"] = value
+            if not is_batch and "p=" in value:
+                page_match = re.search(r"p=(\d+)", value)
+                if page_match:
+                    page = int(page_match.group(1))
+                    self.result["video_name"] += f"(p={page})"
 
-            if line.startswith(" 描述文件 "):  # pexpect or wexpect
-                meta_part = line[6:].replace("\r\n", "").replace(" ", "")
-                self.current_type = "metadata"
-                self.current_value = meta_part
+        # 弹幕、字幕、章节信息
+        if line.startswith(" 弹幕 "):
+            self.result["episodes"][self.current_index]["has_danmaku"] = True
+        if line.startswith(" 字幕 "):
+            self.result["episodes"][self.current_index]["has_subtitle"] = True
+        if line.startswith(" 章节 "):
+            self.result["episodes"][self.current_index]["has_chapter_info"] = True
 
-                try:
-                    self.current_value = ast.literal_eval(self.current_value)
-                    self.result["episodes"][self.current_index]["metadata"] = self.current_value
-                except Exception as E:
-                    print(f"{E}")
-                    # 继续收集，可能跨多行
+        # 描述文件
+        if line.startswith(" 描述文件 "):
+            meta_part = line[6:].replace("\r\n", "").replace(" ", "")
+            try:
+                metadata = ast.literal_eval(meta_part)
+                self.result["episodes"][self.current_index]["metadata"] = metadata
+                if not is_batch and metadata.get("title"):
+                    self.result["episodes"][self.current_index]["title"] = metadata["title"]
+            except Exception as e:
+                print(f"{e}")
 
-            # 提取封面链接（如果之前没提取到）
-            if line.startswith(" 封面 ") and "http" in line:
-                self.current_value = line[4:].replace(" ", "").replace("\r\n", "")
-                self.current_type = "cover_link"
-                self.result["episodes"][self.current_index][self.current_type] = str(self.current_value)
+        # 封面
+        if line.startswith(" 封面 ") and "http" in line:
+            cover_link = line[4:].replace(" ", "").replace("\r\n", "")
+            self.result["episodes"][self.current_index]["cover_link"] = cover_link
 
-            # 处理视频流
-            # TODO 考虑不用 match 直接用 if in.
-            if line.startswith(" 视频质量 "):
-                self.current_type = "video_quality_list"
-                quality_match = re.search(r"<([^>]*)>", line)
-                if quality_match:
-                    quality: VideoQuality = quality_match.group(1).strip()  # type: ignore
-                    self.current_value = quality
-                    self.result["episodes"][self.current_index][self.current_type].append(self.current_value)
-            # 处理音频流
-            if line.startswith(" 音频质量 "):
-                self.current_type = "audio_quality_list"
-                bitrate_match = re.search(r"<([^>]*)>", line)
-                if bitrate_match:
-                    bitrate: AudioQuality = bitrate_match.group(1).strip()  # type:ignore
-                    self.current_value = bitrate
-                    self.result["episodes"][self.current_index][self.current_type].append(self.current_value)
+        # 视频质量
+        if line.startswith(" 视频质量 "):
+            quality_match = re.search(r"<([^>]*)>", line)
+            if quality_match:
+                quality = quality_match.group(1).strip()
+                if quality not in list(get_args(VideoQuality)):
+                    raise ValueError(f"未知清晰度: {quality}")
+                self.result["episodes"][self.current_index]["video_quality_list"].append(quality)  # type: ignore
+
+        # 音频质量
+        if line.startswith(" 音频质量 "):
+            bitrate_match = re.search(r"<([^>]*)>", line)
+            if bitrate_match:
+                bitrate = bitrate_match.group(1).strip()
+                if bitrate not in list(get_args(AudioQuality)):
+                    raise ValueError(f"未知清晰度: {bitrate}")
+                self.result["episodes"][self.current_index]["audio_quality_list"].append(bitrate)  # type: ignore
 
     def get_result(self) -> YuttoParseResult:
         """获取当前的解析结果"""

--- a/src/uiya/utils/TextHelper.py
+++ b/src/uiya/utils/TextHelper.py
@@ -60,6 +60,17 @@ class YuttoOutputParser:
         self.current_value = ""
         self.current_type = ""
         self.current_index = -1
+        self.video_name_types = [
+            "投稿视频",
+            "番剧",
+            "视频合集",
+            "收藏夹",
+            "用户收藏夹",
+            "课程",
+            "视频列表",
+            "UP 主投稿视频",
+            "稍后再看",
+        ]
 
     # 只解析单集
     def parse_line(self, line: str) -> None:
@@ -86,11 +97,9 @@ class YuttoOutputParser:
             )
 
         # 提取视频名称
-        if line.startswith(" 投稿视频 "):
-            if " 投稿视频 " in line:
-                self.current_value = line[6:].replace(" ", "")
-                # else:
-                #     self.current_value = line.split("\x1b[30m\x1b[46m 投稿视频 \x1b[0m")[1].replace(" ", "")
+        for video_name_type in self.video_name_types:
+            if line.startswith(f" {video_name_type} "):
+                self.current_value = line[len(video_name_type) + 2].replace(" ", "")
                 self.current_type = "video_name"
                 self.result[self.current_type] = self.current_value.strip()
                 self.result["episodes"][0]["title"] = self.current_value.strip()
@@ -169,9 +178,10 @@ class YuttoOutputParser:
         """
         # 清理行
         # 提取视频名称
-        if line.startswith(" 投稿视频 "):
-            if " 投稿视频 " in line:
-                self.current_value = line[6:].replace(" ", "")
+        # 提取视频名称
+        for video_name_type in self.video_name_types:
+            if line.startswith(f" {video_name_type} "):
+                self.current_value = line[len(video_name_type) + 2].replace(" ", "")
                 self.current_type = "video_name"
                 self.result[self.current_type] = self.current_value.strip()
                 return None

--- a/src/uiya/utils/TextHelper.py
+++ b/src/uiya/utils/TextHelper.py
@@ -63,6 +63,7 @@ class YuttoOutputParser:
 
     # 只解析单集
     def parse_line(self, line: str) -> None:
+        print([line])
         """
         逐行解析输出
         """
@@ -85,21 +86,18 @@ class YuttoOutputParser:
             )
 
         # 提取视频名称
-        if "\x1b[30;46m 投稿视频 \x1b[0m" in line or "\x1b[30m\x1b[46m 投稿视频 \x1b[0m" in line:  # pexpect or wexpect
-            if "\x1b[30;46m 投稿视频 \x1b[0m" in line:
-                self.current_value = line.split("\x1b[30;46m 投稿视频 \x1b[0m")[1].replace(" ", "")
-            else:
-                self.current_value = line.split("\x1b[30m\x1b[46m 投稿视频 \x1b[0m")[1].replace(" ", "")
-            self.current_type = "video_name"
-            self.result[self.current_type] = self.current_value.strip()
-            self.result["episodes"][0]["title"] = self.current_value.strip()
-            return None
+        if line.startswith(" 投稿视频 "):
+            if " 投稿视频 " in line:
+                self.current_value = line[6:].replace(" ", "")
+                # else:
+                #     self.current_value = line.split("\x1b[30m\x1b[46m 投稿视频 \x1b[0m")[1].replace(" ", "")
+                self.current_type = "video_name"
+                self.result[self.current_type] = self.current_value.strip()
+                self.result["episodes"][0]["title"] = self.current_value.strip()
+                return None
 
-        if "\x1b[30;46m LINK \x1b[0m" in line or "\x1b[30m\x1b[46m LINK \x1b[0m" in line:  # pexpect or wexpect
-            if "\x1b[30;46m LINK \x1b[0m" in line:
-                self.current_value = line.split("\x1b[30;46m LINK \x1b[0m")[1].replace(" ", "").replace("\r\n", "")
-            else:
-                self.current_value = line.split("\x1b[30m\x1b[46m LINK \x1b[0m")[1].replace(" ", "").replace("\r\n", "")
+        if line.startswith(" LINK "):  # pexpect or wexpect
+            self.current_value = line[6:].replace(" ", "").replace("\r\n", "")
             self.current_type = "link"
             self.result["episodes"][0][self.current_type] = self.current_value
             # 如果 LINK 以 p=? 结尾,那么提取 ?
@@ -110,31 +108,26 @@ class YuttoOutputParser:
                     self.result["video_name"] += f"(p={page})"
 
         # 检查是否有弹幕
-        if "\x1b[30;46m 弹幕 \x1b[0m" in line or "\x1b[30m\x1b[46m 弹幕 \x1b[0m" in line:
+        if line.startswith(" 弹幕 "):
             self.current_value = True
             self.current_type = "has_danmaku"
             self.result["episodes"][0][self.current_type] = self.current_value
 
         # 检查是否有字幕
-        if "\x1b[30;46m 字幕 \x1b[0m" in line or "\x1b[30m\x1b[46m 字幕 \x1b[0m" in line:
+        if line.startswith(" 字幕 "):
             self.current_value = True
             self.current_type = "has_subtitle"
             self.result["episodes"][0][self.current_type] = self.current_value
 
         # 检查是否有章节信息
-        if "\x1b[30;46m 章节 \x1b[0m" in line or "\x1b[30m\x1b[46m 章节 \x1b[0m" in line:
+        if line.startswith(" 章节 "):
             self.current_value = True
             self.current_type = "has_chapter_info"
             self.result["episodes"][0][self.current_type] = self.current_value
 
-        if (
-            "\x1b[30;46m 描述文件 \x1b[0m " in line or "\x1b[30m\x1b[46m 描述文件 \x1b[0m " in line
-        ):  # pexpect or wexpect
+        if line.startswith(" 描述文件 "):  # pexpect or wexpect
             # 提取从"描述文件"后面的所有内容作为元数据开始
-            if "\x1b[30;46m 描述文件 \x1b[0m " in line:
-                meta_part = line.split("\x1b[30;46m 描述文件 \x1b[0m ", 1)[1].replace("\r\n", "").replace(" ", "")
-            else:
-                meta_part = line.split("\x1b[30m\x1b[46m 描述文件 \x1b[0m ", 1)[1].replace("\r\n", "").replace(" ", "")
+            meta_part = line[6:].replace("\r\n", "").replace(" ", "")
             self.current_type = "metadata"
             self.current_value = meta_part
 
@@ -148,35 +141,21 @@ class YuttoOutputParser:
                 # 继续收集，可能跨多行
 
         # 提取封面链接（如果之前没提取到）
-        if ("\x1b[30;46m 封面 \x1b[0m" in line or "\x1b[30m\x1b[46m 封面 \x1b[0m " in line) and "http" in line:
-            if "\x1b[30;46m 封面 \x1b[0m" in line:
-                self.current_value = line.split("\x1b[30;46m 封面 \x1b[0m")[1].replace(" ", "").replace("\r\n", "")
-            elif "\x1b[30m\x1b[46m 封面 \x1b[0m":
-                self.current_value = line.split("\x1b[30m\x1b[46m 封面 \x1b[0m")[1].replace(" ", "").replace("\r\n", "")
+        if line.startswith(" 封面 ") and "http" in line:
+            self.current_value = line[4:].replace(" ", "").replace("\r\n", "")
             self.current_type = "cover_link"
             self.result["episodes"][0][self.current_type] = str(self.current_value)
 
-        # 进入视频流部分
-        if "\x1b[94m INFO \x1b[0m 共包含以下" in line and "视频流" in line:
+        if line.startswith(" 视频质量 "):
             self.current_type = "video_quality_list"
-            self.result["episodes"][self.current_index]["video_quality_list"] = []
-            return None
-
-        # 进入音频流部分
-        if "\x1b[94m INFO \x1b[0m 共包含以下" in line and "个音频流" in line:
-            self.current_type = "audio_quality_list"
-            self.result["episodes"][self.current_index]["audio_quality_list"] = []
-
-        # 处理视频流
-        # TODO 考虑不用 match 直接用 if in.
-        if self.current_type == "video_quality_list":
             quality_match = re.search(r"<([^>]*)>", line)
             if quality_match:
                 quality: VideoQuality = quality_match.group(1).strip()  # type: ignore
                 self.current_value = quality
                 self.result["episodes"][self.current_index][self.current_type].append(self.current_value)
         # 处理音频流
-        if self.current_type == "audio_quality_list":
+        if line.startswith(" 音频质量 "):
+            self.current_type = "audio_quality_list"
             bitrate_match = re.search(r"<([^>]*)>", line)
             if bitrate_match:
                 bitrate: AudioQuality = bitrate_match.group(1).strip()  # type:ignore
@@ -190,17 +169,15 @@ class YuttoOutputParser:
         """
         # 清理行
         # 提取视频名称
-        if "\x1b[30;46m 投稿视频 \x1b[0m" in line or "\x1b[30m\x1b[46m 投稿视频 \x1b[0m" in line:  # pexpect or wexpect
-            if "\x1b[30;46m 投稿视频 \x1b[0m" in line:
-                self.current_value = line.split("\x1b[30;46m 投稿视频 \x1b[0m")[1].replace(" ", "")
-            else:
-                self.current_value = line.split("\x1b[30m\x1b[46m 投稿视频 \x1b[0m")[1].replace(" ", "")
-            self.current_type = "video_name"
-            self.result[self.current_type] = self.current_value.strip()
-            return None
+        if line.startswith(" 投稿视频 "):
+            if " 投稿视频 " in line:
+                self.current_value = line[6:].replace(" ", "")
+                self.current_type = "video_name"
+                self.result[self.current_type] = self.current_value.strip()
+                return None
 
         # 提取总集数
-        if "\x1b[94m INFO \x1b[0m 全" in line and "话" in line:  # wexpect and pexpect as the same
+        if line.startswith(" 全集 "):  # wexpect and pexpect as the same
             episodes_count_match = re.search(r"全\s+(\d+)\s+话", line)
             if episodes_count_match:
                 self.current_value = episodes_count_match.group(1)
@@ -209,7 +186,7 @@ class YuttoOutputParser:
             return None
 
         # 新的一集开始
-        if "\x1b[30;46m [" in line or "\x1b[30m\x1b[46m [" in line:  # pexpect or wexpect
+        if line.startswith(" ["):  # [2/4]
             pattern = r"\[(\d+)/(\d+)\]\s+(.*)"
             episode_start_match = re.search(pattern, line)
             if episode_start_match:
@@ -237,44 +214,31 @@ class YuttoOutputParser:
         # collect episode info
         if self.current_index != -1:
             # 提取链接
-            if "\x1b[30;46m LINK \x1b[0m" in line or "\x1b[30m\x1b[46m LINK \x1b[0m" in line:  # pexpect or wexpect
-                if "\x1b[30;46m LINK \x1b[0m" in line:
-                    self.current_value = line.split("\x1b[30;46m LINK \x1b[0m")[1].replace(" ", "").replace("\r\n", "")
-                else:
-                    self.current_value = (
-                        line.split("\x1b[30m\x1b[46m LINK \x1b[0m")[1].replace(" ", "").replace("\r\n", "")
-                    )
+            if line.startswith(" LINK"):  # pexpect or wexpect
+                self.current_value = line[6:].replace(" ", "").replace("\r\n", "")
                 self.current_type = "link"
                 self.result["episodes"][self.current_index][self.current_type] = self.current_value
 
             # 检查是否有弹幕
-            if "\x1b[30;46m 弹幕 \x1b[0m" in line or "\x1b[30m\x1b[46m 弹幕 \x1b[0m" in line:
+            if line.startswith(" 弹幕 "):
                 self.current_value = True
                 self.current_type = "has_danmaku"
                 self.result["episodes"][self.current_index][self.current_type] = self.current_value
 
             # 检查是否有字幕
-            if "\x1b[30;46m 字幕 \x1b[0m" in line or "\x1b[30m\x1b[46m 字幕 \x1b[0m" in line:
+            if line.startswith(" 字幕 "):
                 self.current_value = True
                 self.current_type = "has_subtitle"
                 self.result["episodes"][self.current_index][self.current_type] = self.current_value
 
             # 检查是否有章节信息
-            if "\x1b[30;46m 章节 \x1b[0m" in line or "\x1b[30m\x1b[46m 章节 \x1b[0m" in line:
+            if line.startswith(" 章节 "):
                 self.current_value = True
                 self.current_type = "has_chapter_info"
                 self.result["episodes"][self.current_index][self.current_type] = self.current_value
 
-            if (
-                "\x1b[30;46m 描述文件 \x1b[0m " in line or "\x1b[30m\x1b[46m 描述文件 \x1b[0m " in line
-            ):  # pexpect or wexpect
-                # 提取从"描述文件"后面的所有内容作为元数据开始
-                if "\x1b[30;46m 描述文件 \x1b[0m " in line:
-                    meta_part = line.split("\x1b[30;46m 描述文件 \x1b[0m ", 1)[1].replace("\r\n", "").replace(" ", "")
-                else:
-                    meta_part = (
-                        line.split("\x1b[30m\x1b[46m 描述文件 \x1b[0m ", 1)[1].replace("\r\n", "").replace(" ", "")
-                    )
+            if line.startswith(" 描述文件 "):  # pexpect or wexpect
+                meta_part = line[6:].replace("\r\n", "").replace(" ", "")
                 self.current_type = "metadata"
                 self.current_value = meta_part
 
@@ -286,37 +250,23 @@ class YuttoOutputParser:
                     # 继续收集，可能跨多行
 
             # 提取封面链接（如果之前没提取到）
-            if ("\x1b[30;46m 封面 \x1b[0m" in line or "\x1b[30m\x1b[46m 封面 \x1b[0m " in line) and "http" in line:
-                if "\x1b[30;46m 封面 \x1b[0m" in line:
-                    self.current_value = line.split("\x1b[30;46m 封面 \x1b[0m")[1].replace(" ", "").replace("\r\n", "")
-                elif "\x1b[30m\x1b[46m 封面 \x1b[0m":
-                    self.current_value = (
-                        line.split("\x1b[30m\x1b[46m 封面 \x1b[0m")[1].replace(" ", "").replace("\r\n", "")
-                    )
+            if line.startswith(" 封面 ") and "http" in line:
+                self.current_value = line[4:].replace(" ", "").replace("\r\n", "")
                 self.current_type = "cover_link"
                 self.result["episodes"][self.current_index][self.current_type] = str(self.current_value)
 
-            # 进入视频流部分
-            if "\x1b[94m INFO \x1b[0m 共包含以下" in line and "视频流" in line:
-                self.current_type = "video_quality_list"
-                self.result["episodes"][self.current_index]["video_quality_list"] = []
-                return None
-
-            # 进入音频流部分
-            if "\x1b[94m INFO \x1b[0m 共包含以下" in line and "个音频流" in line:
-                self.current_type = "audio_quality_list"
-                self.result["episodes"][self.current_index]["audio_quality_list"] = []
-
             # 处理视频流
             # TODO 考虑不用 match 直接用 if in.
-            if self.current_type == "video_quality_list":
+            if line.startswith(" 视频质量 "):
+                self.current_type = "video_quality_list"
                 quality_match = re.search(r"<([^>]*)>", line)
                 if quality_match:
                     quality: VideoQuality = quality_match.group(1).strip()  # type: ignore
                     self.current_value = quality
                     self.result["episodes"][self.current_index][self.current_type].append(self.current_value)
             # 处理音频流
-            if self.current_type == "audio_quality_list":
+            if line.startswith(" 音频质量 "):
+                self.current_type = "audio_quality_list"
                 bitrate_match = re.search(r"<([^>]*)>", line)
                 if bitrate_match:
                     bitrate: AudioQuality = bitrate_match.group(1).strip()  # type:ignore

--- a/src/uiya/utils/TextHelper.py
+++ b/src/uiya/utils/TextHelper.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import ast
 import platform
 import re
-from typing import TYPE_CHECKING, get_args
+from typing import get_args
 
 from uiya._dictionary import emoji
-
-
 from uiya._typing import AudioQuality, VideoQuality, YuttoParseResult
 
 

--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -224,10 +224,7 @@ def run_parser(command: list[str], debug: bool = False, batch: bool = True) -> Y
 
             if update_condition:
                 output_text += "".join(buffer)
-                if batch:
-                    parser.batch_parse_line("".join(buffer))
-                else:
-                    parser.parse_line("".join(buffer))
+                parser.parse_line(line="".join(buffer), is_batch=batch)
                 current_index = parser.current_index
                 if current_index - show_index == 1:
                     # 避免加入重复的元素 skip -1
@@ -246,10 +243,7 @@ def run_parser(command: list[str], debug: bool = False, batch: bool = True) -> Y
 
             if buffer:
                 output_text += "".join(buffer)
-                if batch:
-                    parser.batch_parse_line("".join(buffer))
-                else:
-                    parser.parse_line("".join(buffer))
+                parser.parse_line(line="".join(buffer), is_batch=batch)
                 current_index = parser.current_index
             break
 

--- a/src/uiya/yutto_uiya.py
+++ b/src/uiya/yutto_uiya.py
@@ -184,6 +184,7 @@ def bangumi_tab() -> None:
         status["url"] = url
         status["batch_download"] = True
         status["parse_mode"] = True
+        status["no_color"] = True
         if parse_status(status, output_placeholder=output_placeholder):  # 解析状态
             command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
             command = command_generator.gen_args()
@@ -197,6 +198,7 @@ def bangumi_tab() -> None:
         status["url"] = url
         status["batch_download"] = False
         status["parse_mode"] = True
+        status["no_color"] = True
         if parse_status(status, output_placeholder=output_placeholder):
             command_generator = CommandGenerator.from_status(status)  # 通过from_status来初始化
             command = command_generator.gen_args()

--- a/uv.lock
+++ b/uv.lock
@@ -1150,7 +1150,7 @@ wheels = [
 
 [[package]]
 name = "uiya-yutto"
-version = "0.0.1"
+version = "0.0.2rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1162,9 +1162,9 @@ dependencies = [
     { name = "returns" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/95/b017488049db4ec040a108d923be5ed80f1a83d0848c8c70eb53c1a611fe/uiya_yutto-0.0.1.tar.gz", hash = "sha256:55fa457d2387aeede167a3605b5f738b27c60706a7cfb7898dd0bd0c63c1b0a5", size = 334213, upload-time = "2025-05-12T13:24:37.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/1e/fb1ea2c35f04ca4125dc4d789c9286dc547e3888a22bba840f760fd748ff/uiya_yutto-0.0.2rc0.tar.gz", hash = "sha256:f305661c97ecdf5f5112cd4cff3f3703a25fc9d4afb25f2573460641a0aa6161", size = 334291, upload-time = "2025-05-17T03:30:34.277Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/70/d2a1017893cc43fe123faf02a080b6434d68b13ba02df5cd8a2ef0e601f8/uiya_yutto-0.0.1-py3-none-any.whl", hash = "sha256:6c63078b3a5bff93db3c56bcda2b4778aa3864d14c9a5e055fdcb02896602547", size = 104068, upload-time = "2025-05-12T13:24:36.386Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5c/f7bee15106aea50fd4f663483c1b2bb6d88dffb21b029a587bfb9b97232c/uiya_yutto-0.0.2rc0-py3-none-any.whl", hash = "sha256:9a367239bb3d5638751431a91161972591c3a7a3f1a9b38f66fa13c0912c635d", size = 104213, upload-time = "2025-05-17T03:30:33.07Z" },
 ]
 
 [[package]]
@@ -1249,7 +1249,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "streamlit", specifier = "==1.43.2" },
     { name = "tomli-w", specifier = "==1.2.0" },
-    { name = "uiya-yutto", specifier = "==0.0.1" },
+    { name = "uiya-yutto", specifier = "==0.0.2rc0" },
     { name = "wexpect-uv", marker = "sys_platform == 'win32'", specifier = "==0.0.4" },
 ]
 


### PR DESCRIPTION
## 动机

win11 和 win10 终端颜色属性的解释似乎不一样, 虽然外表看上去一样, 导致原本依赖于颜色作为关键字的代码不能用.

所以这里把 Logger 改为 no_color 然后仅以 `startswith(badge_name)` 作为关键字进行匹配.

代码应该在最初就考虑健壮性和优雅性 =-= 这是个教训.

也算是改掉了我看得最不爽的那部分代码了.