### PR TITLE
:bug: fix: Fix unexpected nested loop in download_dir.

### DIFF
--- a/src/uiya/utils/runner.py
+++ b/src/uiya/utils/runner.py
@@ -186,7 +186,7 @@ def run_downloader(command: list[str], output_placeholder: DeltaGenerator) -> in
             continue
 
     # 未经处理的原始字符集
-    print([output_text])
+    # print([output_text])
 
     # 获取退出状态
     child.close()  # type:ignore

--- a/src/uiya/yutto_uiya.py
+++ b/src/uiya/yutto_uiya.py
@@ -84,6 +84,8 @@ def downloader(
     settings = load_settings_file("uiya.toml", UiyaSetting)
     download_dir = settings.download_dir
     video_name = st.session_state[runner_keys["video_name"]]
+    download_dir = Path(download_dir) / video_name
+    download_dir.mkdir(parents=True, exist_ok=True)
     columns = st.columns([1, 1, 1, 1])
     if need_sort:
         audio_quality = natsorted(audio_quality)
@@ -140,8 +142,6 @@ def downloader(
             # 把资源从 tmp_dir 中捞出来
             tmp_dir = Path(command_generator.tmp_dir)
             if tmp_dir.exists():
-                download_dir = Path(download_dir) / video_name
-                download_dir.mkdir(parents=True, exist_ok=True)
                 # print(download_dir)
                 for file in tmp_dir.iterdir():
                     if file.is_file():


### PR DESCRIPTION
修复前:

```shell
文件已保存到: downloads/typing标准库,让IDE重新拥有提示/【持续更新】typing标准库,让IDE重新拥有提示.m4a
文件已保存到: downloads/typing标准库,让IDE重新拥有提示/typing标准库,让IDE重新拥有提示/002typing标准库和环境配置.m4a
文件已保存到: downloads/typing标准库,让IDE重新拥有提示/typing标准库,让IDE重新拥有提示/typing标准库,让IDE重新拥有提示/003内建数据类型.m4a
文件已保存到: downloads/typing标准库,让IDE重新拥有提示/typing标准库,让IDE重新拥有提示/typing标准库,让IDE重新拥有提示/typing标准库,让IDE重新拥有提示/004类和循环引入以及Final修饰符.m4a
```

修复后

```shell
文件已保存到: downloads/typing标准库,让IDE重新拥有提示/【持续更新】typing标准库,让IDE重新拥有提示.m4a
文件已保存到: downloads/typing标准库,让IDE重新拥有提示/002typing标准库和环境配置.m4a
文件已保存到: downloads/typing标准库,让IDE重新拥有提示/003内建数据类型.m4a
文件已保存到: downloads/typing标准库,让IDE重新拥有提示/004类和循环引入以及Final修饰符.m4a
```