### PR TITLE
:construction_worker: ci: cache cargo deps in lint-rust workflow

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
       - name: Install system dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
给 lint-rust 工作流加 `Swatinem/rust-cache@v2`（`workspaces: src-tauri`）。

现状：每次 CI 都在干净的 ubuntu runner 上从零编译整棵依赖树，clippy 一步要跑好几分钟。rust-cache 以 Cargo.lock + 工具链为 key，恢复 cargo registry 和 `src-tauri/target`——依赖不变时热跑通常只剩 1~2 分钟。

首跑（建缓存）不会变快；对本分支的 PR 触发即可看到第二次起的效果。serve 迁移各阶段 PR（`feat/serve-phase-1-lifecycle` 等）都会触发 Rust CI，正好受益。
